### PR TITLE
Emarro/add eval

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,8 +4,11 @@ data_remote: "kuleshov-group/Angiosperm_16_genomes"
 eval_remote: "emarro/maize-allele-frequency-20k-val"
 max_seq_len: 512
 run_name: "pcad1_from_scratch_${pretrained_name_or_path}"
-mlm_probability: 0.15
-repeat_weight: 0.10
+mlm_probability: 0.15 # prob of masking a given token in an input sequence
+mask_replace_prob: 0.80 # prob of replacing a masked token with [MASK]
+random_replace_prob: 0.10 #prob of replacing a masked token with another token in the vocab
+
+repeat_weight: 0.10 #downweight losses for soft-masked DNA regions
 
 from_pretrained: True
 from_scratch: True

--- a/main.py
+++ b/main.py
@@ -296,6 +296,8 @@ def build_dataloader(
     collate_fn = DataCollatorForLanguageModeling(
         tokenizer=tokenizer,
         mlm_probability=cfg.mlm_probability if not mask_seq else 0.0,
+        mask_replace_prob=cfg.mask_replace_prob,
+        random_replace_prob=cfg.random_replace_prob,
     )
 
     return DataLoader(


### PR DESCRIPTION
* Clean up unnecessary part of the code for pre-training using a real dataset (from HF)
* Add zero-shot evaluation based off Maize Allele Frequency task from PCad1 (use dataset subset by Gonzalo)
